### PR TITLE
Integerüberlauf bei Berechnung von CPU-AverageLoad

### DIFF
--- a/IPS2GPIO_RPi/module.php
+++ b/IPS2GPIO_RPi/module.php
@@ -292,11 +292,13 @@
 						// Array neu durchnummerieren
 						$LineOneArray = array_merge($LineOneArray);
 						If (count($LineOneArray) >= 8) {
-							//IPS_LogMessage("IPS2GPIO RPi", serialize($LineOneArray));
+							$this->SendDebug(__CLASS__ . '::' . __FUNCTION__, "LineOneArray=" . print_r($LineOneArray, true), 0);
 							// Idle = idle + iowait
-							$Idle = intval($LineOneArray[3]) + intval($LineOneArray[4]);
+							$Idle = floatval($LineOneArray[3]) + floatval($LineOneArray[4]);
+							$this->SendDebug("IPS2GPIO RPi", "idle=$LineOneArray[3], iowait=$LineOneArray[4] => Idle=$Idle", 0);
 							// NonIdle = user+nice+system+irq+softrig+steal
-							$NonIdle = intval($LineOneArray[0]) + intval($LineOneArray[1]) + intval($LineOneArray[2]) + intval($LineOneArray[5]) + intval($LineOneArray[6]) + intval($LineOneArray[7]);
+							$NonIdle = floatval($LineOneArray[0]) + floatval($LineOneArray[1]) + floatval($LineOneArray[2]) + floatval($LineOneArray[5]) + floatval($LineOneArray[6]) + floatval($LineOneArray[7]);
+							$this->SendDebug(__CLASS__ . '::' . __FUNCTION__, "user=$LineOneArray[0], nice=$LineOneArray[1], system=$LineOneArray[2], irq=$LineOneArray[5], softrig=$LineOneArray[6], steal=$LineOneArray[7] => NonIdle=$NonIdle", 0);
 							// Total = Idle + NonIdle
 							$Total = $Idle + $NonIdle;
 							// Differenzen berechnen
@@ -304,6 +306,7 @@
 							$IdleDiff = $Idle - intval($this->GetBuffer("PrevIdle"));
 							// Auslastung berechnen
 							$CPU_Usage = (($TotalDiff - $IdleDiff) / $TotalDiff);
+							$this->SendDebug(__CLASS__ . '::' . __FUNCTION__, "Total=$Total, Idle=$Idle, TotalDiff=$TotalDiff, IdleDiff=$IdleDiff, CPU_Usage=$CPU_Usage", 0);
 							// Wert nur ausgeben, wenn der Buffer schon einmal mit den aktuellen Werten beschrieben wurde
 							If (intval($this->GetBuffer("PrevTotal")) + intval($this->GetBuffer("PrevIdle")) > 0) {
 								//IPS_LogMessage("IPS2GPIO RPi", "CPU-Auslastung bei ".$CPU_Usage."%");


### PR DESCRIPTION
Bei Server, die längere Zeit laufen, sind die Zahlen, die von /proc/stats ausgegeben werden größer als MAXINT auf 32-bit-Systemen (= 2147483647).
Daher Berechnung auf float umgestellt.